### PR TITLE
Unlink socket before binding

### DIFF
--- a/api/local/local.go
+++ b/api/local/local.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"log"
 	"net"
+	"os"
 
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/reflection"
@@ -31,6 +32,12 @@ func (l *Local) Deregister(ctx context.Context, req *DeregisterRequest) (*Deregi
 }
 
 func (l *Local) Serve(ctx context.Context) error {
+	// unix socket should be unlinked if it exists first
+	// see: https://github.com/golang/go/issues/70985
+	err := os.Remove(l.SocketPath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
 	listener, err := net.Listen("unix", l.SocketPath)
 	if err != nil {
 		return err


### PR DESCRIPTION
A Unix socket should be unlinked before use. See: https://github.com/golang/go/issues/70985

Otherwise we might get errors like this if the agent restarts:
```
2025/08/18 18:58:14 Error: listen unix /var/run/galactic/agent.sock: bind: address already in use
```